### PR TITLE
Add a start script for convenience

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+( sleep 3 ; open "http://localhost:4567/step1" ) &
+ruby app.rb


### PR DESCRIPTION
Simple start script that starts the ruby server and opens the browser window on the `/step1` URL. It's not fool-proof (it just waits for a few seconds to open the browser window) but it works just fine. :)
